### PR TITLE
chore: updata Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 1.0.0
+
+breaking changes
+
+- Table|Crud|Form: remove global config
+- Layout: reimplement the KeepAlive
+- Layout: remove the props `fixed-main`
+- Layout: remove the slots `main-top` `main-bottom`
+- InputTag: change the trigger default value `space` to `enter`
+- Select|TreeSelect|Descriptions: rename the slot parameter data to item
+- rename `useScreenSize` to `useSharedBreakpoint`
+
+feat
+
+- Card: add a new component Card
+- Descriptions: add `render` and `renderLabel` in columns
+- Checkbox|Radio|Select|TreeSelect: cancel the conversion of the data
+- Layout: support transition form RouteMeta
+- Layout: add default slot to custom RouterView
+- Select|TreeSelect: sync props change from element-plus
+- add composables function `useBreakpointWidth` to get reactive Dialog width
+- sync css var change from element-plus
+- sync ComponentSize change from element-plus
+- styles: add cjs form SSR
+- styles: compressed CSS by cssnano
+
+fix
+
+- Form: style error when used gutter
+- Layout: the KeepAlive and Transition do not work
+
+### migration guide
+
+Compare [0.18.3...v1.0.0](https://github.com/tolking/element-pro-components/compare/v0.18.3...v1.0.0)
+
+To support both Transition and KeepAlive, the Layout component had to be refactored. The original internal card-like has been removed.
+
+- It is recommended to use the new Card component to wrap your pages.
+- If you don't care about KeepAlive, you can use default slots to override RouterView to implement global Card wrapping, [demo](https://github.com/tolking/element-pro-components/blob/main/demo/Layout/router-view.vue).
+
+The global configuration has been removed, it is recommended to use related components to pass parameters or internationalization.
+
 ## 0.18.3
 
 feat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "element-pro-components",
-  "version": "0.18.3",
+  "version": "1.0.0",
   "description": "a component library for Vue 3 base on element-plus",
   "main": "lib/element-pro-components.umd.js",
   "module": "lib/element-pro-components.es.js",
@@ -66,8 +66,8 @@
   "dependencies": {
     "@element-plus/icons-vue": "^1.1.4",
     "@vue/shared": "^3.2.31",
-    "@vueuse/core": "^8.2.3",
-    "element-plus": "^2.1.7",
+    "@vueuse/core": "^8.2.4",
+    "element-plus": "^2.1.8",
     "lodash": "^4.17.21",
     "vue": "^3.2.31",
     "vue-router": "^4.0.14"
@@ -117,7 +117,7 @@
     "ts-jest": "^26.5.6",
     "typescript": "^4.6.3",
     "vite": "^2.9.1",
-    "vite-plugin-md": "^0.11.9",
+    "vite-plugin-md": "^0.12.4",
     "vite-plugin-pwa": "^0.11.13",
     "vue-jest": "^5.0.0-alpha.10",
     "vue-tsc": "^0.30.6",


### PR DESCRIPTION
## 1.0.0

breaking changes

- Table|Crud|Form: remove global config
- Layout: reimplement the KeepAlive
- Layout: remove the props `fixed-main`
- Layout: remove the slots `main-top` `main-bottom`
- InputTag: change the trigger default value `space` to `enter`
- Select|TreeSelect|Descriptions: rename the slot parameter data to item
- rename `useScreenSize` to `useSharedBreakpoint`

feat

- Card: add a new component Card
- Descriptions: add `render` and `renderLabel` in columns
- Checkbox|Radio|Select|TreeSelect: cancel the conversion of the data
- Layout: support transition form RouteMeta
- Layout: add default slot to custom RouterView
- Select|TreeSelect: sync props change from element-plus
- add composables function `useBreakpointWidth` to get reactive Dialog width
- sync css var change from element-plus
- sync ComponentSize change from element-plus
- styles: add cjs form SSR
- styles: compressed CSS by cssnano

fix

- Form: style error when used gutter
- Layout: the KeepAlive and Transition do not work

### migration guide

Compare [0.18.3...v1.0.0](https://github.com/tolking/element-pro-components/compare/v0.18.3...v1.0.0)

To support both Transition and KeepAlive, the Layout component had to be refactored. The original internal card-like has been removed.

- It is recommended to use the new Card component to wrap your pages.
- If you don't care about KeepAlive, you can use default slots to override RouterView to implement global Card wrapping, [demo](https://github.com/tolking/element-pro-components/blob/main/demo/Layout/router-view.vue).

The global configuration has been removed, it is recommended to use related components to pass parameters or internationalization.
