### PR TITLE
releases 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 1.2.0
+
+breaking changes
+
+- Menu: remove Link components (#344)
+- Layout: styles (#347)
+- Form: modify the name of the slot (#349)
+- Table: modify the name of the slot (#351)
+- Descriptions: modify the name of the slot (#352)
+- Crud: sync the name change of the slot (#353)
+
+feat
+
+- ColumnSetting: add the default slot (#341)
+
+fix
+
+- Layout: container width error (#336)
+- Crud: prevent click event (#337)
+
+other
+
+- ColumnSetting: sync the props change of ElTree (#340)
+- Select: sync the props change of ElSelect (#342)
+- Table: sync the props change of ElTable (#343)
+- build: remove base attribute of Vite (#354)
+- docs: optimized Code component A11y support (#338)
+
+### migration guide
+
+Compare [1.1.6...v1.2.0](https://github.com/tolking/element-pro-components/compare/v1.1.6...v1.2.0)
+
+In order to customize the Menu and Layout components style, the Link component inside the Menu has been removed in the new version. Therefore, it does not support the jump of complete link routing. If you need this, you need to refer to [Menu demo](https://tolking.github.io/element-pro-components/en-US/components/menu#custom-router) or [Layout demo](https://tolking.github.io/element-pro-components/en-US/components/layout#custom-router) implementation.
+
+In order to avoid errors caused by the same name of [prop] slots and other slots, the new version add the prefix to the [prop] slots of the Form, Table and Descriptions components (same as the Crud component [prop] slots).
+
 ## 1.1.6
 
 feat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "element-pro-components",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "a component library for Vue 3 base on element-plus",
   "main": "lib/index.umd.js",
   "module": "lib/index.es.js",
@@ -26,7 +26,7 @@
     "build:types": "rimraf types && vue-tsc --declaration --emitDeclarationOnly",
     "build:helper": "esno build/build-helper.ts",
     "build:styles": "rimraf lib/styles && esno build/build-styles.ts",
-    "build:docs": "rimraf dist && npm run build:manifest && npm run build:ssr && esno build/prerender.ts",
+    "build:docs": "npm run check && rimraf dist && npm run build:manifest && npm run build:ssr && esno build/prerender.ts",
     "build:manifest": "vite build --ssrManifest --base=/element-pro-components/ --outDir ../dist/static",
     "build:ssr": "vite build --ssr src/entry-server.ts --base=/element-pro-components/ --outDir ../dist/server",
     "check": "npm run lint:test && vue-tsc --noEmit",


### PR DESCRIPTION
breaking changes

- Menu: remove Link components (#344)
- Layout: styles (#347)
- Form: modify the name of the slot (#349)
- Table: modify the name of the slot (#351)
- Descriptions: modify the name of the slot (#352)
- Crud: sync the name change of the slot (#353)

feat

- ColumnSetting: add the default slot (#341)

fix

- Layout: container width error (#336)
- Crud: prevent click event (#337)

other

- ColumnSetting: sync the props change of ElTree (#340)
- Select: sync the props change of ElSelect (#342)
- Table: sync the props change of ElTable (#343)
- build: remove base attribute of Vite (#354)
- docs: optimized Code component A11y support (#338)

### migration guide

Compare [1.1.6...v1.2.0](https://github.com/tolking/element-pro-components/compare/v1.1.6...v1.2.0)

In order to customize the Menu and Layout components style, the Link component inside the Menu has been removed in the new version. Therefore, it does not support the jump of complete link routing. If you need this, you need to refer to [Menu demo](https://tolking.github.io/element-pro-components/en-US/components/menu#custom-router) or [Layout demo](https://tolking.github.io/element-pro-components/en-US/components/layout#custom-router) implementation.

In order to avoid errors caused by the same name of [prop] slots and other slots, the new version add the prefix to the [prop] slots of the Form, Table and Descriptions components (same as the Crud component [prop] slots).
