### PR TITLE
type: add type helper defineComponentProps

### DIFF
--- a/demo/Form/typescript.vue
+++ b/demo/Form/typescript.vue
@@ -8,13 +8,17 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { ElMessage } from 'element-plus'
-import { defineFormColumns, defineFormSubmit } from 'element-pro-components'
+import { markRaw, ref } from 'vue'
+import { ElMessage, ElSwitch } from 'element-plus'
+import {
+  defineFormColumns,
+  defineFormSubmit,
+  defineComponentProps,
+} from 'element-pro-components'
 
 interface Form {
   name?: string
-  address?: string
+  status?: boolean
 }
 
 const form = ref<Form>({})
@@ -22,12 +26,21 @@ const columns = defineFormColumns<Form>([
   {
     label: 'Name',
     prop: 'name',
-    component: 'el-input',
+    component: 'ElInput',
+    props: defineComponentProps<'ElInput'>({
+      clearable: true,
+      placeholder: 'Please input your name',
+    }),
   },
   {
-    label: 'Address',
-    prop: 'address',
-    component: 'el-input',
+    label: 'Status',
+    prop: 'status',
+    component: markRaw(ElSwitch),
+    props: defineComponentProps<typeof ElSwitch>({
+      inlinePrompt: true,
+      activeText: 'Y',
+      inactiveText: 'N',
+    }),
   },
 ])
 const submit = defineFormSubmit((done, isValid, invalidFields) => {

--- a/demo/Form/typescript.vue
+++ b/demo/Form/typescript.vue
@@ -30,6 +30,9 @@ const columns = defineFormColumns<Form>([
     props: defineComponentProps<'ElInput'>({
       clearable: true,
       placeholder: 'Please input your name',
+      slots: {
+        append: () => 'Search',
+      },
     }),
   },
   {

--- a/docs/en-US/components/Form.md
+++ b/docs/en-US/components/Form.md
@@ -29,7 +29,7 @@ When columns is bound to a reactive array, changes in the array will affect form
 
 ### Intellisense
 
-Use the `defineFormColumns` `defineFormMenuColumns` `defineFormSubmit` to make it easier to define columns
+Use the `defineFormColumns` `defineFormMenuColumns` `defineFormSubmit` `defineComponentProps` to make it easier to define columns
 
 ::: demo
 @/demo/Form/define.vue
@@ -179,7 +179,7 @@ To implement Async Form, columns must be bound to a reactive array
 
 ### TypeScript
 
-The function `defineFormColumns` supports passing in a Generics type to infer the value of `prop`
+The function `defineFormColumns` supports passing in a Generics type to infer the value of `prop`, The function `defineComponentProps` supports passing in a Generics type to help input the `props` value
 
 ::: demo
 @/demo/Form/typescript.vue

--- a/docs/zh-CN/components/Form.md
+++ b/docs/zh-CN/components/Form.md
@@ -29,7 +29,7 @@ meta:
 
 ### 智能提示
 
-通过辅助函数 `defineFormColumns` `defineFormMenuColumns` `defineFormSubmit` 提供智能提示
+通过辅助函数 `defineFormColumns` `defineFormMenuColumns` `defineFormSubmit` `defineComponentProps` 提供智能提示
 
 ::: demo
 @/demo/Form/define.vue
@@ -179,7 +179,7 @@ meta:
 
 ### TypeScript
 
-`defineFormColumns` 支持传入一个泛型用来推断 `prop` 值
+`defineFormColumns` 支持传入一个泛型用来推断 `prop` 值；`defineComponentProps` 支持传入一个泛型用来辅助输入 `props` 值
 
 ::: demo
 @/demo/Form/typescript.vue

--- a/src/Form/props.ts
+++ b/src/Form/props.ts
@@ -12,7 +12,11 @@ import {
 } from '../utils/index'
 import type { Component, PropType } from 'vue'
 import type { CollapseModelValue, TabPaneName } from 'element-plus'
-import type { ExternalParam, UnknownObject } from '../types/index'
+import type {
+  ColumnPropsSlots,
+  ExternalParam,
+  UnknownObject,
+} from '../types/index'
 import type {
   IFormColumns,
   IFormMenuColumns,
@@ -54,7 +58,7 @@ export const formComponentProps = {
     type: [String, Object] as PropType<string | Component>,
     default: 'span',
   },
-  slots: [Function, Object, String],
+  slots: [Function, Object, String] as PropType<ColumnPropsSlots>,
 }
 
 const _formItemProps = objectPick(formItemProps, 'prefix', 'indexes')

--- a/src/Form/type.ts
+++ b/src/Form/type.ts
@@ -4,6 +4,7 @@ import {
   formListProps,
   groupFormProps,
   formItemProps,
+  formComponentProps,
   formEmits,
   formItemEmits,
   arrayFormEmits,
@@ -31,6 +32,7 @@ import type {
   ColumnProp,
   FormColumnChildren,
   ColumnComponent,
+  ColumnPropsSlots,
 } from '../types/index'
 
 export interface InvalidFields {
@@ -43,7 +45,7 @@ export interface FormColumn<T = ExternalParam>
   /** component name */
   component?: string | ColumnComponent
   /** props for component */
-  props?: UnknownObject
+  props?: UnknownObject & { slots?: ColumnPropsSlots }
   /** the type of sub-form */
   type?: 'array'
   /** sub-form */
@@ -156,6 +158,7 @@ export type IArrayFormProps = IDefineProps<typeof arrayFormProps>
 export type IFormListProps = IDefineProps<typeof formListProps>
 export type IGroupFormProps = IDefineProps<typeof groupFormProps>
 export type IFormItemProps = IDefineProps<typeof formItemProps>
+export type IFormComponentProps = IDefineProps<typeof formComponentProps>
 export type IFormEmits = IDefineEmits<typeof formEmits>
 export type IFormItemEmits = IDefineEmits<typeof formItemEmits>
 export type IArrayFormEmits = IDefineEmits<typeof arrayFormEmits>

--- a/src/Form/type.ts
+++ b/src/Form/type.ts
@@ -10,7 +10,7 @@ import {
   tabsFormEmits,
   stepsFormEmits,
 } from './props'
-import type { Component, Ref, Slots } from 'vue'
+import type { Ref, Slots } from 'vue'
 import type {
   ButtonProps,
   ColProps,
@@ -30,6 +30,7 @@ import type {
   Mutable,
   ColumnProp,
   FormColumnChildren,
+  ColumnComponent,
 } from '../types/index'
 
 export interface InvalidFields {
@@ -40,7 +41,7 @@ export interface FormColumn<T = ExternalParam>
   extends Mutable<Partial<Omit<FormItemProps, 'prop'>>>,
     Partial<Omit<ColProps, 'tag'>> {
   /** component name */
-  component?: string | Component
+  component?: string | ColumnComponent
   /** props for component */
   props?: UnknownObject
   /** the type of sub-form */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
+export * from './props'
 export * from './public'
 export * from './router'

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,9 +1,11 @@
 import type { Component, GlobalComponents } from 'vue'
-import type { UnknownObject } from './index'
+import type { UnknownObject, UnknownFunction } from './index'
 
 type ComponentInstance = Component & { new (...args: unknown[]): unknown }
 
 export type ColumnComponent = ComponentInstance | keyof GlobalComponents
+
+export type ColumnPropsSlots = string | UnknownObject | UnknownFunction
 
 type ExtractProps<T extends ComponentInstance> = InstanceType<T>['$props']
 
@@ -76,7 +78,7 @@ export type ExtractComponentProps<T extends ColumnComponent> =
  * ```
  */
 export function defineComponentProps<T extends ColumnComponent>(
-  props: ExtractComponentProps<T>
-): ExtractComponentProps<T> {
+  props: ExtractComponentProps<T> & { slots?: ColumnPropsSlots }
+): ExtractComponentProps<T> & { slots?: ColumnPropsSlots } {
   return props
 }

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,0 +1,82 @@
+import type { Component, GlobalComponents } from 'vue'
+import type { UnknownObject } from './index'
+
+type ComponentInstance = Component & { new (...args: unknown[]): unknown }
+
+export type ColumnComponent = ComponentInstance | keyof GlobalComponents
+
+type ExtractProps<T extends ComponentInstance> = InstanceType<T>['$props']
+
+/**
+ * Extract props types from component
+ *
+ * Support passing in a component type
+ *
+ * @example
+ * ```ts
+ *  import { ElInput } from 'element-plus'
+ *  type ElInputProps = ExtractComponentProps<typeof ElInput>
+ *  // Output
+ *  Partial<{
+ *    readonly type: string;
+ *    readonly disabled: boolean;
+ *    readonly label: string;
+ *    ...
+ *  }>
+ * ```
+ *
+ * Support passing in a component name defined in the GlobalComponents. Before using, you need to import the component definition file to the global. Refer to [element-plus](https://element-plus.org/en-US/guide/quickstart.html#volar-support) and [element-pro-components](https://tolking.github.io/element-pro-components/en-US/guide/#start-using)
+ *
+ * @example
+ * ```ts
+ *  type ElInputProps = ExtractComponentProps<'ElInput'>
+ *  // Output
+ *  Partial<{
+ *    readonly type: string;
+ *    readonly disabled: boolean;
+ *    readonly label: string;
+ *    ...
+ *  }>
+ * ```
+ */
+export type ExtractComponentProps<T extends ColumnComponent> =
+  T extends ComponentInstance
+    ? ExtractProps<T>
+    : T extends keyof GlobalComponents
+    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      ExtractProps<GlobalComponents[T]>
+    : UnknownObject
+
+/**
+ * Type helper to make it easier to define props of component
+ * @param props the props of component
+ *
+ * *Pass in a generic to obtain the props types*
+ *
+ * Support passing in a component type
+ *
+ * @example
+ * ```ts
+ *  import { ElInput } from 'element-plus'
+ *  const ElInputProps = defineComponentProps<typeof ElInput>({
+ *    type: 'text',
+ *    size: 'large',
+ *  })
+ * ```
+ *
+ * Support passing in a component name defined in the GlobalComponents. Before using, you need to import the component definition file to the global. Refer to [element-plus](https://element-plus.org/en-US/guide/quickstart.html#volar-support) and [element-pro-components](https://tolking.github.io/element-pro-components/en-US/guide/#start-using)
+ *
+ * @example
+ * ```ts
+ *  const ElInputProps = defineComponentProps<'ElInput'>({
+ *    type: 'text',
+ *    size: 'large',
+ *  })
+ * ```
+ */
+export function defineComponentProps<T extends ColumnComponent>(
+  props: ExtractComponentProps<T>
+): ExtractComponentProps<T> {
+  return props
+}

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -50,9 +50,8 @@ type DeepNested<K extends string, V> = V extends object[]
 /**
  * Get the deep key path of the object
  *
- * for example:
- *
- * ```
+ * @example
+ * ```ts
  *  DeepPath<{
  *    name: string
  *    address: string


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://tolking.github.io/element-pro-components/en-US/guide/contributing) | [中文](https://tolking.github.io/element-pro-components/zh-CN/guide/contributing).
- [x] Make sure you are merging your commits to `main` branch.
- [x] Make sure you pass the code formatting test (`pnpm check`).
- [x] Make sure you pass the test (`pnpm test`).
- [x] Add some descriptions and refer to relative issues for your PR. <!-- e.g. `fix #100` or `close #100, close #101` (#xxx is the issue id) -->

link #374

- add ExtractComponentProps to extract props types from component

```ts
import { ElInput } from 'element-plus'
type ElInputProps = ExtractComponentProps<typeof ElInput>
// or
type ElInputProps = ExtractComponentProps<'ElInput'>
```

- add type helper defineComponentProps

```ts
import { ElInput } from 'element-plus'
const ElInputProps = defineComponentProps<typeof ElInput>({
  type: 'text',
  size: 'large',
})
// or
const ElInputProps = defineComponentProps<'ElInput'>({
  type: 'text',
  size: 'large',
})
```